### PR TITLE
Remove reference to mod that's no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Once the game has loaded. Wait until there are no more messages on the top left 
   - Simple Action: Hidden
 - Configuration → Wheel Layout :
   - Current Wheel : 2
-  - Set it up however you like, but it's recommended to have Pray/Call Horse.
+  - Set it up however you like, but it's recommended to have Pray.
 
 #### Expanded Towns
 - Settings → Fortification Wall :


### PR DESCRIPTION
The Call Horse ability that integrates with Easy Wheel is a feature from Immersive Horses, which is no longer a part of the modlist. We use Simple Horses now which uses it's own hotkey.